### PR TITLE
Reduce specificity of guzzle version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "6.2.*"
+        "guzzlehttp/guzzle": "^6.2"
     },
     "autoload": {
         "psr-4": { "Evoluted\\Feefo\\": ["src/"] }


### PR DESCRIPTION
This change allows better compatibility with other modules which require specific versions of `guzzle`.